### PR TITLE
[Feature] Add test for Kafka dataset registration and deletion

### DIFF
--- a/scidx/client/__init__.py
+++ b/scidx/client/__init__.py
@@ -21,6 +21,7 @@ from .update_kafka import update_kafka
 from .update_url import update_url
 
 from .delete_organization import delete_organization
+from .delete_resource import delete_resource
 
 # Add the methods to sciDXClient
 sciDXClient.register_organization = register_organization
@@ -41,3 +42,5 @@ sciDXClient.update_kafka = update_kafka
 sciDXClient.update_url = update_url
 
 sciDXClient.delete_organization = delete_organization
+sciDXClient.delete_resource = delete_resource
+

--- a/scidx/client/delete_resource.py
+++ b/scidx/client/delete_resource.py
@@ -1,0 +1,48 @@
+import requests
+
+def delete_resource(self, resource_name: str) -> dict:
+    """
+    Delete a resource (e.g., Kafka, URL, S3) in the sciDX REST API.
+
+    Parameters
+    ----------
+    resource_name : str
+        The name of the resource to be deleted.
+
+    Returns
+    -------
+    dict
+        A dictionary containing the response from the API.
+
+    Raises
+    ------
+    HTTPError
+        If the API request fails with detailed error information.
+    """
+    # Define the URL for the DELETE request using the resource_name
+    url = f"{self.api_url}/{resource_name}"
+    
+    # Get headers for authorization or other needed parameters
+    headers = self._get_headers()
+
+    # Make the DELETE request to the API
+    response = requests.delete(url, headers=headers)
+    
+    # If the response is successful, return the confirmation message
+    if response.status_code == 200:
+        return response.json()
+    # If the resource is not found, raise an HTTPError with a detailed message
+    elif response.status_code == 404:
+        raise requests.exceptions.HTTPError(
+            f"Resource '{resource_name}' not found.", 
+            response=response
+        )
+    # For other cases, raise an HTTPError with a detailed message
+    else:
+        error_message = (
+            f"Failed to delete resource '{resource_name}'. "
+            f"Request URL: {url}\n"
+            f"Response Status Code: {response.status_code}\n"
+            f"Response Content: {response.content.decode('utf-8')}"
+        )
+        raise requests.exceptions.HTTPError(error_message, response=response)

--- a/tests/test_register_and_delete_kafka_dataset_and_org.py
+++ b/tests/test_register_and_delete_kafka_dataset_and_org.py
@@ -1,0 +1,81 @@
+import pytest
+import string
+import random
+from scidx.client import sciDXClient
+
+# Helper function to generate a random string
+def generate_random_string(length=8):
+    """
+    Generate a random string of fixed length.
+    """
+    letters = string.ascii_lowercase
+    return ''.join(random.choice(letters) for i in range(length))
+
+# Test for registering and then deleting a Kafka dataset and its organization
+def test_register_and_delete_kafka_dataset_and_org():
+    """
+    Test the ability to create and then delete a Kafka dataset 
+    and the associated organization using the real API.
+    """
+    # Create a client instance with the actual API URL
+    client = sciDXClient(api_url="http://localhost:8765")
+    
+    # Set the token for authentication
+    client.token = "test"
+    
+    # Step 1: Create a random organization
+    org_name = generate_random_string()
+    org_title = f"Title for {org_name}"
+    org_description = "This is a test organization created for testing."
+
+    # Register a new organization
+    response_create_org = client.register_organization(
+        name=org_name,
+        title=org_title,
+        description=org_description
+    )
+    
+    # Check if the organization was created successfully
+    assert "id" in response_create_org
+    assert response_create_org.get("id") is not None  # Ensure an ID is returned
+    
+    # Extract the organization ID
+    owner_org = response_create_org.get("id")
+    
+    # Step 2: Create a random Kafka dataset
+    kafka_dataset_name = generate_random_string()
+    kafka_dataset_title = f"Kafka Dataset {kafka_dataset_name}"
+    kafka_topic = generate_random_string(6)
+    kafka_host = "localhost"
+    kafka_port = 9092
+    kafka_dataset_description = "This is a test Kafka dataset."
+
+    # Register the Kafka dataset
+    response_create_kafka = client.register_kafka(
+        dataset_name=kafka_dataset_name,
+        dataset_title=kafka_dataset_title,
+        owner_org=owner_org,
+        kafka_topic=kafka_topic,
+        kafka_host=kafka_host,
+        kafka_port=kafka_port,
+        dataset_description=kafka_dataset_description
+    )
+
+    # Debugging: Print the Kafka dataset response to inspect it
+    print("Create Kafka Dataset Response:", response_create_kafka)
+
+    # Check if the Kafka dataset was created successfully
+    assert "id" in response_create_kafka
+    assert response_create_kafka.get("id") is not None  # Ensure an ID is returned
+    
+    # Step 3: Delete the Kafka dataset
+    response_delete_kafka = client.delete_resource(resource_name=kafka_dataset_name)
+    
+    # Check if the Kafka dataset was deleted successfully
+    assert response_delete_kafka.get("message") == f"{kafka_dataset_name} deleted successfully"
+    
+    # Step 4: Delete the organization
+    response_delete_org = client.delete_organization(organization_name=org_name)
+    
+    # Check if the organization was deleted successfully
+    assert response_delete_org.get("message") == "Organization deleted successfully"


### PR DESCRIPTION
This pull request introduces a new test that covers the following functionality:
- Register a Kafka dataset with a random name.
- Delete the registered Kafka dataset.
- Register and delete a temporary organization used for the Kafka dataset.

The test ensures that the dataset and the organization are correctly created and removed using the API, verifying their successful integration.
