### PR TITLE
Add beta staging query

### DIFF
--- a/docs/api/query_array.md
+++ b/docs/api/query_array.md
@@ -1,0 +1,50 @@
+# query_array
+
+Download a subset of an array within a dataset previously registered as external data with sciDX.
+
+## Parameters
+- `source` (str): the name of the external source.
+- `var_name` (str): the name of the array to access.
+- `lb` (tuple of ints): the lower-bounds of array indices to access.
+- `ub` (tuple of ints): the upper-bounds of array indices to access.
+- `dataset_name` (str): The name of the dataset. (Optional)
+- `dataset_title` (str): The title of the dataset. (Optional)
+- `owner_org` (str): The ID of the organization. (Optional)
+### Temporal search parameters
+- `timestamp` (str or datetime): find a result nearest in time to the given timestamp. (Optional)
+- `time_direction` (TimeDirection): either `TimeDirection.FUTURE` or `TimeDirection.PAST`. If the former, and `timestamp` is given, then "nearest in time" looks forward in time; if the latter, backwards. Default behavior is forward-looking.
+- `start_time` and `end_time` (str or datetime): these two parameters define a time interval that filters results. If either is absent, then the interval is endless in that direction. If `timestamp` is set, these parameters are ignored.
+
+## Returns
+
+- A `list` of `tuples`, one for each matching registered dataset, in ascending order by `timestamp`. Each tuple consists of:
+
+1. The subsetted data for the requested variable or `None` if no data is available.
+2. The timestamp of the dataset or `None` if it is not timestamped.
+3. A metadata `dict` associated with the registered datasest in sciDX
+
+## Raises
+
+- `Exception`: if the query fails for any reason other than no results found.
+
+## Example
+
+```python
+from scidx.client import sciDXClient
+from datetime import datetime
+import requests
+
+
+# Initialize the client
+client = sciDXClient(api_url)
+
+# Query the goes18 source, which has been previously registered
+result = client.query_array(
+            source="goes18",
+            var_name="Mask", 
+            lb = (10, 20), 
+            ub = (200,300),
+            start_time="2024-01-06T0532", end_time="2024-01-06T0542"
+        )
+
+Return to [Usage](../usage.md)

--- a/docs/api/query_array.md
+++ b/docs/api/query_array.md
@@ -12,8 +12,8 @@ Download a subset of an array within a dataset previously registered as external
 - `owner_org` (str): The ID of the organization. (Optional)
 ### Temporal search parameters
 - `timestamp` (str or datetime): find a result nearest in time to the given timestamp. (Optional)
-- `time_direction` (TimeDirection): either `TimeDirection.FUTURE` or `TimeDirection.PAST`. If the former, and `timestamp` is given, then "nearest in time" looks forward in time; if the latter, backwards. Default behavior is forward-looking.
-- `start_time` and `end_time` (str or datetime): these two parameters define a time interval that filters results. If either is absent, then the interval is endless in that direction. If `timestamp` is set, these parameters are ignored.
+- `time_direction` (TimeDirection): either `TimeDirection.FUTURE` or `TimeDirection.PAST`. If the former, and `timestamp` is given, then "nearest in time" looks forward in time; if the latter, backwards. Default behavior is forward-looking. (Optional)
+- `start_time` and `end_time` (str or datetime): these two parameters define a time interval that filters results. If either is absent, then the interval is endless in that direction. If `timestamp` is set, these parameters are ignored. (Optional)
 
 ## Returns
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -22,6 +22,9 @@ This document provides an index of the functions available in the `scidx` librar
 - [search_datasources](./api/search_datasource.md)
 - [search_resource](./api/search_resource.md)
 
+## Query
+- [query_array](./api/query_array.md)
+
 ## Deletion
 
 - [delete_organization](./api/delete_organization.md)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pytest
 pytest-order
 aiokafka
 pytest-asyncio
+python-dateutil

--- a/scidx/client/__init__.py
+++ b/scidx/client/__init__.py
@@ -21,16 +21,18 @@ from .update_s3 import update_s3
 from .update_kafka import update_kafka
 from .update_url import update_url
 
+from .query import query_array
+from .query import TimeDirection
 
 from .delete_resource import delete_resource
 from .delete_organization import delete_organization
 from .delete_resource import delete_resource
 
+
 # Add the methods to sciDXClient
 sciDXClient.register_organization = register_organization
 sciDXClient.search_organization = search_organization
 sciDXClient.search_resource = search_resource
-sciDXClient.complex_search = complex_search
 sciDXClient.register_url = register_url
 sciDXClient.register_kafka = register_kafka
 sciDXClient.register_s3 = register_s3
@@ -45,6 +47,7 @@ sciDXClient.update_s3 = update_s3
 sciDXClient.update_kafka = update_kafka
 sciDXClient.update_url = update_url
 
+sciDXClient.query_array = query_array
 
 sciDXClient.delete_organization = delete_organization
 sciDXClient.delete_resource = delete_resource

--- a/scidx/client/__init__.py
+++ b/scidx/client/__init__.py
@@ -7,6 +7,7 @@ from .register_kafka import register_kafka
 
 from .search_resource import search_resource
 from .search_organization import search_organization
+from .complex_search import complex_search
 
 from .get_api_token import get_api_token
 from .login import login
@@ -29,6 +30,7 @@ from .delete_resource import delete_resource
 sciDXClient.register_organization = register_organization
 sciDXClient.search_organization = search_organization
 sciDXClient.search_resource = search_resource
+sciDXClient.complex_search = complex_search
 sciDXClient.register_url = register_url
 sciDXClient.register_kafka = register_kafka
 sciDXClient.register_s3 = register_s3

--- a/scidx/client/complex_search.py
+++ b/scidx/client/complex_search.py
@@ -2,7 +2,7 @@ import requests
 from typing import Optional, List
 
 
-def search_resource(self, dataset_name: Optional[str] = None, dataset_title: Optional[str] = None,
+def complex_search(self, dataset_name: Optional[str] = None, dataset_title: Optional[str] = None,
                     owner_org: Optional[str] = None, resource_url: Optional[str] = None,
                     resource_name: Optional[str] = None, dataset_description: Optional[str] = None,
                     resource_description: Optional[str] = None, resource_format: Optional[str] = None,
@@ -43,7 +43,7 @@ def search_resource(self, dataset_name: Optional[str] = None, dataset_title: Opt
     HTTPError
         If the API request fails with detailed error information.
     """
-    url = f"{self.api_url}/search"
+    url = f"{self.api_url}/search/complex"
     params = {
         "dataset_name": dataset_name,
         "dataset_title": dataset_title,
@@ -59,7 +59,7 @@ def search_resource(self, dataset_name: Optional[str] = None, dataset_title: Opt
     # Remove None values from params
     params = {k: v for k, v in params.items() if v is not None}
 
-    response = requests.get(url, params=params)
+    response = requests.post(url, json=params)
     if response.status_code == 200:
         return response.json()
     else:

--- a/scidx/client/query.py
+++ b/scidx/client/query.py
@@ -71,9 +71,46 @@ def _get_data_from_staging(staging_handle: str, var_name: str, staging_socket: s
         raise StagingFailure("registered data not found in staging.")
     return(data, parser.isoparse(timestamp))
 
-
 def query_array(self, source: str,  var_name: str, lb: tuple[int], ub: tuple[int], dataset_name: Optional[str] = None, dataset_title: Optional[str] = None,
             owner_org: Optional[str] = None, **kwargs) -> list[tuple]:
+    """
+    Download a subset of an array within a dataset previously registered as external data with sciDX.
+
+    Parameters
+    ----------
+    source : str
+        The name of the external source.
+    var_name : str
+        The name of the array to access.
+    lb : tuple[int]
+        The lower-bounds of array indices to access.
+    ub : tuple[int]
+        The upper-bounds of array indices to access.
+    dataset_name : str, optional
+        The name of the dataset.
+    dataset_title : str, optional
+        The title of the dataset.
+    owner_org : str, optional
+        The ID of the organization
+    timestamp : str or datetime, optional
+        Find a result nearest in time to the given timestamp.
+    time_direction : TimeDirection
+        Either `TimeDirection.FUTURE` or `TimeDirection.PAST`. If the former, and `timestamp` is given, then "nearest in time" looks forward in time; if the latter, backwards. Default behavior is forward-looking.
+    start_time : str or datetime, optional
+        The start of a time interval, which stretches to the infinite future if end_time is not given
+    end_time: str or datetime, optional
+        The end of a time interval, which stretches to the infinite past if start_time is not given.
+
+    Returns
+    -------
+    list[Tuple[NDArray, datetime, dict]]
+        A list of tuples, one per matching dataset. Each tuple consists of the matching subset, the timestamp of the dataset or None, and a metadata dict for the dataset.
+    
+    Raises
+    ------
+    Exception
+        If the query fails for any reason other than no results found.
+    """
     if not DXSpacesClient:
         raise NotImplementedError("querying requires beta staging support. Please build scidx[staging].")
     if not len(lb) == len(ub):

--- a/scidx/client/query.py
+++ b/scidx/client/query.py
@@ -1,0 +1,97 @@
+import datetime
+from dateutil import parser
+from enum import Enum
+import json
+from typing import Optional
+
+try:
+    from dxspaces import DXSpacesClient
+except ImportError:
+    DXSpacesClient = None
+from .search_resource import search_resource
+
+class TimeDirection(Enum):
+    FUTURE = 1
+    PAST = 2
+
+    def __str__(self):
+        if self == TimeDirection.FUTURE:
+            return(">")
+        else:
+            return("<")
+
+class StagingFailure(Exception):
+    pass
+
+_excluded_extras = ['staging_handle', 'staging_socket']
+
+def _time_arg_to_str(arg):
+    if isinstance(arg, str):
+        time = parser.isoparse(arg)
+    elif isinstance(arg, datetime):
+        time = arg
+    else:
+        raise ValueError("timestamp must be a datetime or a parseable datetime string")
+    return(time.strftime('%Y-%m-%dT%H:%M:%S'))
+
+def _get_query_time_string(**kwargs):
+    if 'timestamp' in kwargs:
+        tstamp_str = _time_arg_to_str(kwargs['timestamp'])
+        tstamp_direction = TimeDirection.FUTURE
+        if 'time_direction' in kwargs:
+            if not isinstance(kwargs['time_direction'], TimeDirection):
+                raise ValueError("time_direction should be FUTURE or PAST")
+            tstamp_direction = kwargs['tstamp_direction']
+        return(f'{tstamp_direction}{tstamp_str}')
+    time_string = None
+    if 'start_time' in kwargs:
+        time_string = _time_arg_to_str(kwargs['start_time']) + '/'
+    if 'end_time' in kwargs:
+        end_time_string = _time_arg_to_str(kwargs['end_time'])
+        if time_string:
+            time_string = time_string + end_time_string
+        else:
+            time_string = '/' + end_time_string
+    return(time_string)
+
+def _get_data_from_staging(staging_handle: str, var_name: str, staging_socket: str, lb: tuple[int], ub: tuple[int], timestamp: str, **kwargs):
+    staging_handle = json.loads(staging_handle)
+    namespace = None
+    if 'namespace' in staging_handle:
+        namespace = staging_handle['namespace']
+        del staging_handle['namespace']
+    name = 'var_name:' + var_name
+    if 'parameters' in staging_handle:
+        params = staging_handle['parameters']
+        for p in params:
+            name = name + f',{p}:{params[p]}'
+    client = DXSpacesClient(staging_socket)
+    data = client.GetNDArray(name=name, version=0, lb=lb, ub=ub, namespace=namespace)
+    if data is None:
+        raise StagingFailure("registered data not found in staging.")
+    return(data, parser.isoparse(timestamp))
+
+
+def query_array(self, source: str,  var_name: str, lb: tuple[int], ub: tuple[int], dataset_name: Optional[str] = None, dataset_title: Optional[str] = None,
+            owner_org: Optional[str] = None, **kwargs) -> list[tuple]:
+    if not DXSpacesClient:
+        raise NotImplementedError("querying requires beta staging support. Please build scidx[staging].")
+    if not len(lb) == len(ub):
+        raise 
+    time_string = _get_query_time_string(**kwargs)
+    filter_list = [f'source:{source}']
+    search_results = self.search_resource(dataset_name, dataset_title, owner_org, timestamp=time_string, filter_list=filter_list)
+    results = []
+    for result in search_results:
+        if 'extras' in result:
+            extras = result['extras']
+            if 'staging_handle' in extras and 'staging_socket' in extras:
+                data, timestamp = _get_data_from_staging(lb=lb, ub=ub, var_name=var_name, **extras)
+                for extra in _excluded_extras:
+                    if extra in extras:
+                        del extras[extra]
+                results.append((data, timestamp, extras))
+    return(results)
+                
+
+    

--- a/scidx/client/register_url.py
+++ b/scidx/client/register_url.py
@@ -1,4 +1,5 @@
 from typing import Union, Optional
+from datetime import datetime
 import requests
 
 class StreamProcessing:
@@ -99,7 +100,7 @@ class NetCDFProcessing:
 
 def register_url(self, resource_name: str, resource_title: str, owner_org: str,
                  resource_url: str, file_type: str, processing: Optional[Union[StreamProcessing, CSVProcessing, TXTProcessing, JSONProcessing, NetCDFProcessing]] = None,
-                 notes: str = "", extras: dict = None, mapping: Optional[dict] = None) -> dict:
+                 notes: str = "", extras: dict = None, mapping: Optional[dict] = None, timestamp: Optional[datetime] = None) -> dict:
     """
     Create a new URL resource in the sciDX system.
 
@@ -119,6 +120,7 @@ def register_url(self, resource_name: str, resource_title: str, owner_org: str,
         The processing information specific to the file type.
     notes : str, optional
         Additional notes about the resource.
+    timestamp : datetime
     extras : dict, optional
         Additional metadata to be added to the resource.
     mapping : dict, optional
@@ -131,6 +133,11 @@ def register_url(self, resource_name: str, resource_title: str, owner_org: str,
     """
     url = f"{self.api_url}/url"
     headers = self._get_headers()
+
+    if timestamp:
+        if not extras:
+            extras = {}
+        extras["timestamp"] = timestamp.strftime('%Y-%m-%dT%H:%M:%S')
 
     # Build the payload
     payload = {

--- a/scidx/client/search_resource.py
+++ b/scidx/client/search_resource.py
@@ -6,7 +6,8 @@ def search_resource(self, dataset_name: Optional[str] = None, dataset_title: Opt
                     owner_org: Optional[str] = None, resource_url: Optional[str] = None,
                     resource_name: Optional[str] = None, dataset_description: Optional[str] = None,
                     resource_description: Optional[str] = None, resource_format: Optional[str] = None,
-                    search_term: Optional[str] = None, timestamp: Optional[str] = None) -> List[dict]:
+                    search_term: Optional[str] = None, filter_list: Optional[list[str]] = [],
+                    timestamp: Optional[str] = None) -> List[dict]:
     """
     Search for resources in the sciDX system by various parameters.
 
@@ -30,6 +31,8 @@ def search_resource(self, dataset_name: Optional[str] = None, dataset_title: Opt
         The format of the dataset resource.
     search_term : Optional[str]
         A term to search across all fields.
+    filter_list : Optional[str]
+        A list of field filters
     timestamp : str, optional
         A formatted time range to filter results
 
@@ -54,12 +57,13 @@ def search_resource(self, dataset_name: Optional[str] = None, dataset_title: Opt
         "resource_description": resource_description,
         "resource_format": resource_format.lower() if resource_format else None,
         "search_term": search_term,
+        "filter_list": filter_list,
         "timestamp": timestamp
     }
     # Remove None values from params
     params = {k: v for k, v in params.items() if v is not None}
 
-    response = requests.get(url, params=params)
+    response = requests.post(url, json=params)
     if response.status_code == 200:
         return response.json()
     else:

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,10 @@ with open('AUTHORS', 'r', encoding='utf-8') as f:
 with open('requirements.txt', 'r', encoding='utf-8') as f:
     requirements = f.read().splitlines()
 
+# Read staging requirements
+with open('staging-requirements.txt', 'r',  encoding='utf-8') as f:
+    staging_requirements = f.read().splitlines()
+
 setup(
     name='scidx',
     version='0.3.0',

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,9 @@ setup(
     url='https://github.com/sci-ndp/scidx-py',
     packages=find_packages(),
     install_requires=requirements,
+    extras_require={
+        'staging': staging_requirements
+    },
     classifiers=[
         'Programming Language :: Python :: 3',
         'License :: OSI Approved :: MIT License',

--- a/staging-requirements.txt
+++ b/staging-requirements.txt
@@ -1,0 +1,1 @@
+dxspaces

--- a/staging-requirements.txt
+++ b/staging-requirements.txt
@@ -1,1 +1,1 @@
-dxspaces
+dxspaces>=0.0.6


### PR DESCRIPTION
This adds the `query_array()` method, which allows the user to pass a source name, a variable name, upper- and lower- bounds, a time stamp/range, and some typical dataset filters (name, description, owner). `query_array()` searches scidx for matching entries with staging handles, and downloads the data within the requested indices for each dataset.

This PR additionally changes the request method in `search_resource()` form a GET to a POST, and adds a timestamp parameter to `register_url()`. In order for registrations to be queryable, they must include a `source` parameter in their `extras`.