### PR TITLE
[tests] test fix (plus)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 env =
-    D:SCIDX_SOCKET=https://example.org:8000
-    D:SCIDX_ORG=<owner-org>
-    D:SCIDX_USER=<username>
-    D:SCIDX_PASSWORD=<secret-password>
+    D:SCIDX_SOCKET=http://devsrv:8000
+    D:SCIDX_ORG=aperture_science
+    D:SCIDX_USER=placeholder@placeholder.com
+    D:SCIDX_PASSWORD=placeholder

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+env =
+    D:SCIDX_SOCKET=https://example.org:8000
+    D:SCIDX_USER=<username>
+    D:SCIDX_PASSWORD=<secret-password>
+    

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 env =
     D:SCIDX_SOCKET=https://example.org:8000
+    D:SCIDX_ORG=<owner-org>
     D:SCIDX_USER=<username>
     D:SCIDX_PASSWORD=<secret-password>
-    

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-requests
+aiokafka
 pytest
 pytest-order
-aiokafka
 pytest-asyncio
+pytest-env
 python-dateutil
+requests

--- a/scidx/client/delete_resource.py
+++ b/scidx/client/delete_resource.py
@@ -1,14 +1,16 @@
 import requests
 
 
-def delete_resource(self, resource_id: str) -> dict:
+def delete_resource(self, resource_name: str = None, resource_id: str = None) -> dict:
     """
     Delete a resource in the sciDX system.
 
     Parameters
     ----------
+    resource_name : str
+        The name of the resource to be deleted.
     resource_id : str
-        The ID of the resource to be deleted.
+        The id of the resource to be deleted.
 
     Returns
     -------
@@ -20,14 +22,25 @@ def delete_resource(self, resource_id: str) -> dict:
     HTTPError
         If the API request fails with detailed error information.
     """
-    # Define the URL for the DELETE request using the resource_name
-    url = f"{self.api_url}/{resource_name}"
+    if bool(resource_name) == bool(resource_id):
+        raise ValueError("exactly one of resource_name and resource_id must not be None")
+
+    
+    # Define the URL for the DELETE request using the resource_name or resource_id
+    url = f"{self.api_url}/resource"
+    if resource_name:
+        url = url + f"/{resource_name}"
+  
+    # Set parameters (either resource_id or nothing)
+    params = {}
+    if resource_id:
+        params["resource_id"] = resource_id
     
     # Get headers for authorization or other needed parameters
     headers = self._get_headers()
 
     # Make the DELETE request to the API
-    response = requests.delete(url, headers=headers)
+    response = requests.delete(url, headers=headers, params=params)
     
     # If the response is successful, return the confirmation message
     if response.status_code == 200:

--- a/scidx/client/query.py
+++ b/scidx/client/query.py
@@ -41,7 +41,7 @@ def _get_query_time_string(**kwargs):
         if 'time_direction' in kwargs:
             if not isinstance(kwargs['time_direction'], TimeDirection):
                 raise ValueError("time_direction should be FUTURE or PAST")
-            tstamp_direction = kwargs['tstamp_direction']
+            tstamp_direction = kwargs['time_direction']
         return(f'{tstamp_direction}{tstamp_str}')
     time_string = None
     if 'start_time' in kwargs:

--- a/scidx/client/query.py
+++ b/scidx/client/query.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime
 from dateutil import parser
 from enum import Enum
 import json

--- a/staging-requirements.txt
+++ b/staging-requirements.txt
@@ -1,1 +1,2 @@
 dxspaces>=0.0.6
+numpy

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+import os
+import pytest
+from scidx.client import sciDXClient
+
+SCIDX_SOCKET=os.environ["SCIDX_SOCKET"]
+SCIDX_ORG=os.environ["SCIDX_ORG"]
+SCIDX_USER=os.environ["SCIDX_USER"]
+SCIDX_PASSWORD=os.environ["SCIDX_PASSWORD"]
+
+@pytest.fixture(scope="module")
+def client():
+    """
+    Fixture to create and login the client for testing.
+    """
+    client = sciDXClient(SCIDX_SOCKET)
+    client.login(SCIDX_USER, SCIDX_PASSWORD)
+    return client

--- a/tests/test_full_organization_flow.py
+++ b/tests/test_full_organization_flow.py
@@ -1,23 +1,16 @@
 import pytest
 import uuid
-from scidx import sciDXClient
+from . import conftest
 
 # Function to generate a unique organization name
 def generate_unique_name(base_name):
     return f"{base_name}_{uuid.uuid4().hex[:6]}"
 
-# Global variables to store IDs and names
-api_url = "http://127.0.0.1:8000"
-USERNAME = "placeholder@placeholder.com"
-PASSWORD = "placeholder"
-
 @pytest.fixture(scope="module", autouse=True)
-def setup_and_cleanup():
-    global client, organization_name, organization_data
+def setup_and_cleanup(client):
+    global organization_name, organization_data
 
-    # Initialize client and login to get the token
-    client = sciDXClient(api_url)
-    client.login(USERNAME, PASSWORD)
+    # get client token
     token = client.token
 
     # Create organization data with token
@@ -46,8 +39,8 @@ def setup_and_cleanup():
 
 # Test to create an organization
 @pytest.mark.order(1)
-def test_create_organization():
-    global client, organization_data
+def test_create_organization(client):
+    global organization_data
     response = client.register_organization(
         name=organization_data["name"],
         title=organization_data["title"],

--- a/tests/test_full_s3_flow.py
+++ b/tests/test_full_s3_flow.py
@@ -1,25 +1,12 @@
+import os
 import pytest
 import random
 import string
-from scidx.client import sciDXClient
 
-# Constants
-API_URL = "http://localhost:8000"
-OWNER_ORG = "test_org"
-USERNAME = "placeholder@placeholder.com"
-PASSWORD = "placeholder"
+SCIDX_ORG=os.environ["SCIDX_ORG"]
 
 def generate_unique_name():
     return ''.join(random.choices(string.ascii_lowercase + string.digits, k=6))
-
-@pytest.fixture
-def client():
-    """
-    Fixture to create and login the client for testing.
-    """
-    client = sciDXClient(API_URL)
-    client.login(USERNAME, PASSWORD)
-    return client
 
 def verify_resource_exists(client, search_term, expected_name):
     """
@@ -41,7 +28,7 @@ def test_s3_resource_flow(client):
     incorrect_s3_data = {
         "resource_name": resource_name,
         "resource_title": "Incorrect S3 Resource Title",
-        "owner_org": OWNER_ORG,
+        "owner_org": SCIDX_ORG,
         "resource_s3": "s3://wrong-bucket/resource",
         "notes": "This is an incorrect S3 resource for testing.",
         "extras": {"wrong_key1": "wrong_value1", "wrong_key2": "wrong_value2"}

--- a/tests/test_full_url_flow.py
+++ b/tests/test_full_url_flow.py
@@ -1,25 +1,14 @@
+import os
 import pytest
 import random
 import string
-from scidx.client import sciDXClient, StreamProcessing, CSVProcessing, TXTProcessing, JSONProcessing, NetCDFProcessing
+from scidx.client import StreamProcessing, CSVProcessing, TXTProcessing, JSONProcessing, NetCDFProcessing
+from . import conftest
 
-# Constants
-API_URL = "http://localhost:8000"
-OWNER_ORG = "test_org"
-USERNAME = "placeholder@placeholder.com"
-PASSWORD = "placeholder"
+SCIDX_ORG=os.environ["SCIDX_ORG"]
 
 def generate_unique_name():
     return ''.join(random.choices(string.ascii_lowercase + string.digits, k=6))
-
-@pytest.fixture
-def client():
-    """
-    Fixture to create and login the client for testing.
-    """
-    client = sciDXClient(API_URL)
-    client.login(USERNAME, PASSWORD)
-    return client
 
 def verify_resource_exists(client, search_term, expected_name):
     """
@@ -43,7 +32,7 @@ def test_stream_url(client):
     response = client.register_url(
         resource_name=resource_name,
         resource_title="Stream Resource Example",
-        owner_org=OWNER_ORG,
+        owner_org=SCIDX_ORG,
         resource_url="http://example.com/stream",
         file_type="stream",
         processing=stream_processing,
@@ -81,7 +70,7 @@ def test_stream_url(client):
     
     # Ensure the resource is deleted at the end of the test
     print("\n=== Deleting Stream Resource ===")
-    delete_response = client.delete_resource(resource_id)
+    delete_response = client.delete_resource(resource_id=resource_id)
     print(f"Deleted resource: {delete_response}")
     assert delete_response.get("message") == f"{resource_id} deleted successfully", "Failed to delete stream resource"
 
@@ -98,7 +87,7 @@ def test_csv_url(client):
     response = client.register_url(
         resource_name=resource_name,
         resource_title="CSV Resource Example",
-        owner_org=OWNER_ORG,
+        owner_org=SCIDX_ORG,
         resource_url="http://example.com/csv",
         file_type="CSV",
         processing=csv_processing,
@@ -136,7 +125,7 @@ def test_csv_url(client):
     
     # Ensure the resource is deleted at the end of the test
     print("\n=== Deleting CSV Resource ===")
-    delete_response = client.delete_resource(resource_id)
+    delete_response = client.delete_resource(resource_id=resource_id)
     print(f"Deleted resource: {delete_response}")
     assert delete_response.get("message") == f"{resource_id} deleted successfully", "Failed to delete stream resource"
 
@@ -152,7 +141,7 @@ def test_txt_url(client):
     response = client.register_url(
         resource_name=resource_name,
         resource_title="TXT Resource Example",
-        owner_org=OWNER_ORG,
+        owner_org=SCIDX_ORG,
         resource_url="http://example.com/txt",
         file_type="TXT",
         processing=txt_processing,
@@ -190,7 +179,7 @@ def test_txt_url(client):
     
     # Ensure the resource is deleted at the end of the test
     print("\n=== Deleting TXT Resource ===")
-    delete_response = client.delete_resource(resource_id)
+    delete_response = client.delete_resource(resource_id=resource_id)
     print(f"Deleted resource: {delete_response}")
     assert delete_response.get("message") == f"{resource_id} deleted successfully", "Failed to delete stream resource"
 
@@ -206,7 +195,7 @@ def test_json_url(client):
     response = client.register_url(
         resource_name=resource_name,
         resource_title="JSON Resource Example",
-        owner_org=OWNER_ORG,
+        owner_org=SCIDX_ORG,
         resource_url="http://example.com/json",
         file_type="JSON",
         processing=json_processing,
@@ -244,7 +233,7 @@ def test_json_url(client):
     
         # Ensure the resource is deleted at the end of the test
     print("\n=== Deleting JSON Resource ===")
-    delete_response = client.delete_resource(resource_id)
+    delete_response = client.delete_resource(resource_id=resource_id)
     print(f"Deleted resource: {delete_response}")
     assert delete_response.get("message") == f"{resource_id} deleted successfully", "Failed to delete stream resource"
 
@@ -260,8 +249,8 @@ def test_netcdf_url(client):
     response = client.register_url(
         resource_name=resource_name,
         resource_title="NetCDF Resource Example",
-        owner_org=OWNER_ORG,
-        resource_url="http://example.com/netcdf",
+        owner_org=SCIDX_ORG,
+        resource_url="http://example.com/netcdf.nc",
         file_type="NetCDF",
         processing=netcdf_processing,
         notes="This is a NetCDF resource for testing.",
@@ -298,7 +287,7 @@ def test_netcdf_url(client):
     
     # Ensure the resource is deleted at the end of the test
     print("\n=== Deleting NetCDF Resource ===")
-    delete_response = client.delete_resource(resource_id)
+    delete_response = client.delete_resource(resource_id=resource_id)
     print(f"Deleted resource: {delete_response}")
     assert delete_response.get("message") == f"{resource_id} deleted successfully", "Failed to delete stream resource"
 

--- a/tests/test_get_api_token.py
+++ b/tests/test_get_api_token.py
@@ -1,32 +1,30 @@
+import os
 import pytest
 from requests.exceptions import HTTPError
-from scidx.client import sciDXClient
+from . import conftest
+
+SCIDX_USER=os.environ["SCIDX_USER"]
+SCIDX_PASSWORD=os.environ["SCIDX_PASSWORD"]
 
 # Test for successfully retrieving an API token
-def test_get_api_token_success():
+def test_get_api_token_success(client):
     """
     Test that the get_api_token function correctly retrieves an 
     access token when the authentication is successful.
     """
-    # Create a client instance with the actual API URL
-    client = sciDXClient(api_url="http://localhost:8765")
-    
     # Call the get_api_token method with the real credentials
-    token = client.get_api_token(username="test", password="test")
+    token = client.get_api_token(username=SCIDX_USER, password=SCIDX_PASSWORD)
     
     # Check that the token is not None or empty
     assert token is not None
     assert len(token) > 0
 
 # Test for failed API token retrieval due to incorrect credentials
-def test_get_api_token_failure():
+def test_get_api_token_failure(client):
     """
     Test that the get_api_token function raises an HTTPError when 
     the authentication fails due to incorrect credentials.
     """
-    # Create a client instance with the actual API URL
-    client = sciDXClient(api_url="http://localhost:8765")
-    
     # Attempt to retrieve the token with incorrect credentials
     with pytest.raises(HTTPError) as exc_info:
         client.get_api_token(username="wrong_user", password="wrong_password")

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,33 +1,30 @@
+import os
 import pytest
 from requests.exceptions import HTTPError
-from scidx.client import sciDXClient
+from . import conftest
+
+SCIDX_USER=os.environ["SCIDX_USER"]
+SCIDX_PASSWORD=os.environ["SCIDX_PASSWORD"]
 
 # Test for successful login to the real API
-def test_login_success_real_api():
+def test_login_success_real_api(client):
     """
     Test that the login function correctly sets the access token
     when authenticating against the real API at localhost:8765.
     """
-    # Create a client instance with the actual API URL
-    client = sciDXClient(api_url="http://localhost:8765")
-    
-    # Call the login method with the real credentials
-    client.login(username="test", password="test")
+    client.login(username=SCIDX_USER, password=SCIDX_PASSWORD)
     
     # Check that the token was set and is not None or empty
     assert client.token is not None
     assert len(client.token) > 0
 
 # Test for failed login to the real API
-def test_login_failure_real_api():
+def test_login_failure_real_api(client):
     """
     Test that the login function raises an HTTPError when the 
     authentication request fails against the real API at 
     localhost:8765.
     """
-    # Create a client instance with the actual API URL
-    client = sciDXClient(api_url="http://localhost:8765")
-    
     # Attempt to login with incorrect credentials
     with pytest.raises(HTTPError) as exc_info:
         client.login(username="wrong_user", password="wrong_password")

--- a/tests/test_query_array.py
+++ b/tests/test_query_array.py
@@ -1,0 +1,66 @@
+from scidx.client import NetCDFProcessing, TimeDirection
+from datetime import datetime
+import numpy as np
+import os
+import pytest
+import random
+import string
+from . import conftest
+
+SCIDX_ORG=os.environ["SCIDX_ORG"]
+
+def generate_unique_name():
+    return ''.join(random.choices(string.ascii_lowercase + string.digits, k=6))
+
+def test_query_array(client):
+    """
+    Test registering and querying a netCDF resource
+    """
+    resource_name = "query_test_" + generate_unique_name()
+    netcdf_processing = NetCDFProcessing(group="example_group")
+    resource_url="https://raw.githubusercontent.com/sci-ndp/scidx-py/refs/heads/main/tests/data/example.nc"
+    source = "test_source_" + generate_unique_name()
+
+    response = client.register_url(
+        resource_name = resource_name,
+        resource_title="NetCDF Resource Example",
+        owner_org=SCIDX_ORG,
+        resource_url=resource_url,
+        file_type="NetCDF",
+        processing=netcdf_processing,
+        notes="This is a NetCDF resource for testing.",
+        timestamp=datetime.today(),
+        extras={"source": source}
+    )
+    resource_id = response.get("id")
+    assert resource_id
+
+    result = client.query_array(
+        source = source, 
+        var_name = "example", 
+        lb = (3, 4), 
+        ub = (5,6), 
+        timestamp=datetime.today())
+    
+    assert len(result) == 0
+
+    timestamp = datetime.today().strftime('%Y%m%dT%H%M%S')
+
+    result = client.query_array(
+        source = source, 
+        var_name = "example", 
+        lb = (3,4), 
+        ub = (5,6), 
+        timestamp=timestamp,
+        time_direction=TimeDirection.PAST)
+    
+    assert len(result) == 1
+
+    (data,_,_) = result[0]
+    validation_data = (np.arange(360).reshape((20,18)))[3:6,4:7]
+    assert (data == validation_data).all()
+    
+    delete_response = client.delete_resource(resource_name=resource_name)
+    assert delete_response.get("message") == f"{resource_name} deleted successfully"
+
+    

--- a/tests/test_register_and_delete_organization.py
+++ b/tests/test_register_and_delete_organization.py
@@ -1,7 +1,7 @@
 import pytest
 import string
 import random
-from scidx.client import sciDXClient
+from . import conftest
 
 # Helper function to generate a random string
 def generate_random_string(length=8):
@@ -12,14 +12,11 @@ def generate_random_string(length=8):
     return ''.join(random.choice(letters) for i in range(length))
 
 # Test for registering and then deleting an organization
-def test_register_and_delete_organization():
+def test_register_and_delete_organization(client):
     """
     Test the ability to create and then delete an organization 
     using the real API.
     """
-    # Create a client instance with the actual API URL
-    client = sciDXClient(api_url="http://localhost:8765")
-    
     # Set the token for authentication
     client.token = "test"
 

--- a/tests/test_register_and_delete_s3_and_org.py
+++ b/tests/test_register_and_delete_s3_and_org.py
@@ -1,7 +1,6 @@
 import pytest
 import string
 import random
-from scidx.client import sciDXClient
 
 # Helper function to generate a random string
 def generate_random_string(length=8):
@@ -12,14 +11,11 @@ def generate_random_string(length=8):
     return ''.join(random.choice(letters) for i in range(length))
 
 # Test for registering and then deleting an S3 dataset and its organization
-def test_register_and_delete_s3_dataset_and_org():
+def test_register_and_delete_s3_dataset_and_org(client):
     """
     Test the ability to create and then delete an S3 dataset 
     and the associated organization using the real API.
     """
-    # Create a client instance with the actual API URL
-    client = sciDXClient(api_url="http://localhost:8765")
-    
     # Set the token for authentication
     client.token = "test"
     

--- a/tests/test_search_organization.py
+++ b/tests/test_search_organization.py
@@ -1,7 +1,7 @@
 import pytest
 import string
 import random
-from scidx.client import sciDXClient
+from . import conftest
 
 # Helper function to generate a random string
 def generate_random_string(length=8):
@@ -12,13 +12,10 @@ def generate_random_string(length=8):
     return ''.join(random.choice(letters) for i in range(length))
 
 # Test for searching and verifying organization listing
-def test_search_organization():
+def test_search_organization(client):
     """
     Test the ability to list all organizations in the system.
     """
-    # Create a client instance with the actual API URL
-    client = sciDXClient(api_url="http://localhost:8765")
-    
     # Set the token for authentication
     client.token = "test"
     

--- a/tests/test_search_resource_with_all_parameters.py
+++ b/tests/test_search_resource_with_all_parameters.py
@@ -1,8 +1,8 @@
 import pytest
 import string
 import random
-from scidx.client import sciDXClient
 from scidx.client import CSVProcessing
+from . import conftest
 
 # Helper function to generate a random string
 def generate_random_string(length=8):
@@ -13,13 +13,10 @@ def generate_random_string(length=8):
     return ''.join(random.choice(letters) for i in range(length))
 
 # Test for searching resources using all available parameters
-def test_search_resource_with_all_parameters():
+def test_search_resource_with_all_parameters(client):
     """
     Test the ability to search for resources in the system using all available parameters.
     """
-    # Create a client instance with the actual API URL
-    client = sciDXClient(api_url="http://localhost:8765")
-    
     # Set the token for authentication
     client.token = "test"
     


### PR DESCRIPTION
This PR does cleanup on tests. It moves client configuration into environment variables (with a template that the user can use to set them in `pytest.ini`. As part of this, I have updated `delete_resource()` to optionally take one of a `resource_id` or a `resource_name`. `resource_name` remains the first positional parameter, so the API should be backwards compatible.  This relies on the API providing the `DELETE /resource` endpoint, which is provided by the PR below:

https://github.com/sci-ndp/scidx-api/pull/106

So that PR should be merged before this one!

This resolves #49.

The Kafka tests are failing for me still, but I don't know whether the socket specified in the tests is valid or not. This aspect needs attention from @Andreufb .
